### PR TITLE
Fix Imports for Xcode 12.5

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -523,9 +523,6 @@
 		008969D82486DAD100DC48C2 /* BSG_KSCrashReportStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0089692C2486DAD000DC48C2 /* BSG_KSCrashReportStore.m */; };
 		008969D92486DAD100DC48C2 /* BSG_KSCrashReportStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0089692C2486DAD000DC48C2 /* BSG_KSCrashReportStore.m */; };
 		008969DA2486DAD100DC48C2 /* BSG_KSCrashReportStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0089692C2486DAD000DC48C2 /* BSG_KSCrashReportStore.m */; };
-		008969DB2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */; };
-		008969DC2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */; };
-		008969DD2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */; };
 		008969DE2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */; };
 		008969DF2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */; };
 		008969E02486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */; };
@@ -601,9 +598,6 @@
 		00896A262486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969472486DAD000DC48C2 /* BSG_KSCrashSentry_Signal.h */; };
 		00896A272486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969472486DAD000DC48C2 /* BSG_KSCrashSentry_Signal.h */; };
 		00896A282486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969472486DAD000DC48C2 /* BSG_KSCrashSentry_Signal.h */; };
-		00896A292486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969482486DAD000DC48C2 /* BSG_KSCrashType.h */; };
-		00896A2A2486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969482486DAD000DC48C2 /* BSG_KSCrashType.h */; };
-		00896A2B2486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969482486DAD000DC48C2 /* BSG_KSCrashType.h */; };
 		00896A2C2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */; };
 		00896A2D2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */; };
 		00896A2E2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */; };
@@ -746,6 +740,14 @@
 		3A700AF824A6492F0068CD1B /* BugsnagError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9124A63A8E0068CD1B /* BugsnagError.h */; };
 		3A700AF924A6492F0068CD1B /* BugsnagDeviceWithState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */; };
 		3A700AFA24A6492F0068CD1B /* BugsnagMetadata.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */; };
+		80A6B46F26307A0300F83BFD /* BSG_KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A6B46D26307A0200F83BFD /* BSG_KSCrashType.h */; };
+		80A6B47026307A0300F83BFD /* BSG_KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A6B46D26307A0200F83BFD /* BSG_KSCrashType.h */; };
+		80A6B47126307A0300F83BFD /* BSG_KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A6B46D26307A0200F83BFD /* BSG_KSCrashType.h */; };
+		80A6B47226307A0300F83BFD /* BSG_KSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A6B46E26307A0200F83BFD /* BSG_KSCrash.h */; };
+		80A6B47326307A0300F83BFD /* BSG_KSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A6B46E26307A0200F83BFD /* BSG_KSCrash.h */; };
+		80A6B47426307A0300F83BFD /* BSG_KSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A6B46E26307A0200F83BFD /* BSG_KSCrash.h */; };
+		80A6B47526307A3900F83BFD /* BSG_KSCrash.h in Sources */ = {isa = PBXBuildFile; fileRef = 80A6B46E26307A0200F83BFD /* BSG_KSCrash.h */; };
+		80A6B47626307A3900F83BFD /* BSG_KSCrashType.h in Sources */ = {isa = PBXBuildFile; fileRef = 80A6B46D26307A0200F83BFD /* BSG_KSCrashType.h */; };
 		E701FA9F2490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */; };
 		E701FAA02490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */; };
 		E701FAA12490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */; };
@@ -847,7 +849,6 @@
 		E746297A24890D3100F92D67 /* BSG_RFC3339DateTool.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969272486DAD000DC48C2 /* BSG_RFC3339DateTool.h */; };
 		E746297B24890D3100F92D67 /* BSG_KSMach.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969282486DAD000DC48C2 /* BSG_KSMach.h */; };
 		E746297C24890D3100F92D67 /* BSG_KSCrashContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692A2486DAD000DC48C2 /* BSG_KSCrashContext.h */; };
-		E746297D24890D3100F92D67 /* BSG_KSCrash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */; };
 		E746297E24890D3100F92D67 /* BSG_KSCrashC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */; };
 		E746297F24890D3100F92D67 /* BSG_KSSystemInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692F2486DAD000DC48C2 /* BSG_KSSystemInfo.h */; };
 		E746298024890D3100F92D67 /* BSG_KSSystemInfoC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969312486DAD000DC48C2 /* BSG_KSSystemInfoC.h */; };
@@ -865,7 +866,6 @@
 		E746298C24890D3200F92D67 /* BSG_KSCrashSentry_NSException.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969442486DAD000DC48C2 /* BSG_KSCrashSentry_NSException.h */; };
 		E746298D24890D3200F92D67 /* BSG_KSCrashSentry_User.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969462486DAD000DC48C2 /* BSG_KSCrashSentry_User.h */; };
 		E746298E24890D3200F92D67 /* BSG_KSCrashSentry_Signal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969472486DAD000DC48C2 /* BSG_KSCrashSentry_Signal.h */; };
-		E746298F24890D3200F92D67 /* BSG_KSCrashType.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969482486DAD000DC48C2 /* BSG_KSCrashType.h */; };
 		E746299024890D3200F92D67 /* BSG_KSCrashIdentifier.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089694A2486DAD000DC48C2 /* BSG_KSCrashIdentifier.h */; };
 		E746299124890D3200F92D67 /* Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; };
 		E746299424890D3200F92D67 /* BSGOutOfMemoryWatchdog.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00AD1EFC2486A17800A27979 /* BSGOutOfMemoryWatchdog.h */; };
@@ -971,7 +971,6 @@
 				E746297A24890D3100F92D67 /* BSG_RFC3339DateTool.h in CopyFiles */,
 				E746297B24890D3100F92D67 /* BSG_KSMach.h in CopyFiles */,
 				E746297C24890D3100F92D67 /* BSG_KSCrashContext.h in CopyFiles */,
-				E746297D24890D3100F92D67 /* BSG_KSCrash.h in CopyFiles */,
 				E746297E24890D3100F92D67 /* BSG_KSCrashC.h in CopyFiles */,
 				E746297F24890D3100F92D67 /* BSG_KSSystemInfo.h in CopyFiles */,
 				E746298024890D3100F92D67 /* BSG_KSSystemInfoC.h in CopyFiles */,
@@ -989,7 +988,6 @@
 				E746298C24890D3200F92D67 /* BSG_KSCrashSentry_NSException.h in CopyFiles */,
 				E746298D24890D3200F92D67 /* BSG_KSCrashSentry_User.h in CopyFiles */,
 				E746298E24890D3200F92D67 /* BSG_KSCrashSentry_Signal.h in CopyFiles */,
-				E746298F24890D3200F92D67 /* BSG_KSCrashType.h in CopyFiles */,
 				E746299024890D3200F92D67 /* BSG_KSCrashIdentifier.h in CopyFiles */,
 				E746299124890D3200F92D67 /* Private.h in CopyFiles */,
 				E746299424890D3200F92D67 /* BSGOutOfMemoryWatchdog.h in CopyFiles */,
@@ -1171,7 +1169,6 @@
 		0089692A2486DAD000DC48C2 /* BSG_KSCrashContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashContext.h; sourceTree = "<group>"; };
 		0089692B2486DAD000DC48C2 /* BSG_KSCrashType.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSCrashType.c; sourceTree = "<group>"; };
 		0089692C2486DAD000DC48C2 /* BSG_KSCrashReportStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashReportStore.m; sourceTree = "<group>"; };
-		0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrash.h; sourceTree = "<group>"; };
 		0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashC.h; sourceTree = "<group>"; };
 		0089692F2486DAD000DC48C2 /* BSG_KSSystemInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSSystemInfo.h; sourceTree = "<group>"; };
 		008969302486DAD000DC48C2 /* BSG_KSCrashIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashIdentifier.m; sourceTree = "<group>"; };
@@ -1197,7 +1194,6 @@
 		008969452486DAD000DC48C2 /* BSG_KSCrashSentry.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSCrashSentry.c; sourceTree = "<group>"; };
 		008969462486DAD000DC48C2 /* BSG_KSCrashSentry_User.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashSentry_User.h; sourceTree = "<group>"; };
 		008969472486DAD000DC48C2 /* BSG_KSCrashSentry_Signal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashSentry_Signal.h; sourceTree = "<group>"; };
-		008969482486DAD000DC48C2 /* BSG_KSCrashType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashType.h; sourceTree = "<group>"; };
 		008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSCrashReport.c; sourceTree = "<group>"; };
 		0089694A2486DAD000DC48C2 /* BSG_KSCrashIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashIdentifier.h; sourceTree = "<group>"; };
 		0089694B2486DAD000DC48C2 /* BSG_KSCrashC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSCrashC.c; sourceTree = "<group>"; };
@@ -1256,6 +1252,8 @@
 		3A700A9124A63A8E0068CD1B /* BugsnagError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagError.h; sourceTree = "<group>"; };
 		3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagDeviceWithState.h; sourceTree = "<group>"; };
 		3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagMetadata.h; sourceTree = "<group>"; };
+		80A6B46D26307A0200F83BFD /* BSG_KSCrashType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashType.h; sourceTree = "<group>"; };
+		80A6B46E26307A0200F83BFD /* BSG_KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrash.h; sourceTree = "<group>"; };
 		E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagApiValidationTest.m; sourceTree = "<group>"; };
 		E701FAA62490EF77008D842F /* ClientApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ClientApiValidationTest.m; sourceTree = "<group>"; };
 		E701FAAA2490EFD9008D842F /* EventApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EventApiValidationTest.m; sourceTree = "<group>"; };
@@ -1437,7 +1435,6 @@
 				0089692A2486DAD000DC48C2 /* BSG_KSCrashContext.h */,
 				0089692B2486DAD000DC48C2 /* BSG_KSCrashType.c */,
 				0089692C2486DAD000DC48C2 /* BSG_KSCrashReportStore.m */,
-				0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */,
 				0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */,
 				0089692F2486DAD000DC48C2 /* BSG_KSSystemInfo.h */,
 				008969302486DAD000DC48C2 /* BSG_KSCrashIdentifier.m */,
@@ -1451,7 +1448,6 @@
 				008969382486DAD000DC48C2 /* BSG_KSCrashAdvanced.h */,
 				008969392486DAD000DC48C2 /* BSG_KSCrashReportStore.h */,
 				0089693A2486DAD000DC48C2 /* Sentry */,
-				008969482486DAD000DC48C2 /* BSG_KSCrashType.h */,
 				008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */,
 				0089694A2486DAD000DC48C2 /* BSG_KSCrashIdentifier.h */,
 				0089694B2486DAD000DC48C2 /* BSG_KSCrashC.c */,
@@ -1784,6 +1780,8 @@
 		3A700A7F24A63A8E0068CD1B /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				80A6B46E26307A0200F83BFD /* BSG_KSCrash.h */,
+				80A6B46D26307A0200F83BFD /* BSG_KSCrashType.h */,
 				3A700A8024A63A8E0068CD1B /* BugsnagThread.h */,
 				3A700A8124A63A8E0068CD1B /* BugsnagSession.h */,
 				3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */,
@@ -1859,6 +1857,7 @@
 				008968282486DA5600DC48C2 /* BugsnagKeys.h in Headers */,
 				008969BD2486DAD100DC48C2 /* BSG_KSMachHeaders.h in Headers */,
 				008968DE2486DAA700DC48C2 /* BugsnagPluginClient.h in Headers */,
+				80A6B47226307A0300F83BFD /* BSG_KSCrash.h in Headers */,
 				008969EA2486DAD100DC48C2 /* BSG_KSCrashReport.h in Headers */,
 				008969F02486DAD100DC48C2 /* BSG_KSCrashReportFields.h in Headers */,
 				00896A2F2486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
@@ -1877,6 +1876,7 @@
 				008968F42486DAB800DC48C2 /* BugsnagSessionFileStore.h in Headers */,
 				00AD1F1D2486A17900A27979 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				008968882486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
+				80A6B46F26307A0300F83BFD /* BSG_KSCrashType.h in Headers */,
 				00896A082486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
 				0089683E2486DA6C00DC48C2 /* BugsnagMetadataInternal.h in Headers */,
 				008969722486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
@@ -1912,8 +1912,6 @@
 				008969ED2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
 				00AD1F022486A17900A27979 /* RegisterErrorData.h in Headers */,
 				008968ED2486DAB800DC48C2 /* BugsnagFileStore.h in Headers */,
-				00896A292486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */,
-				008969DB2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */,
 				0089696F2486DAD000DC48C2 /* BSG_KSFileUtils.h in Headers */,
 				008969512486DAD000DC48C2 /* BSGOnErrorSentBlock.h in Headers */,
 				00896A052486DAD100DC48C2 /* BSG_KSCrashSentry_MachException.h in Headers */,
@@ -1955,6 +1953,7 @@
 				008968292486DA5600DC48C2 /* BugsnagKeys.h in Headers */,
 				008969BE2486DAD100DC48C2 /* BSG_KSMachHeaders.h in Headers */,
 				008968DF2486DAA700DC48C2 /* BugsnagPluginClient.h in Headers */,
+				80A6B47326307A0300F83BFD /* BSG_KSCrash.h in Headers */,
 				008969EB2486DAD100DC48C2 /* BSG_KSCrashReport.h in Headers */,
 				008969F12486DAD100DC48C2 /* BSG_KSCrashReportFields.h in Headers */,
 				00896A302486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
@@ -1973,6 +1972,7 @@
 				00AD1F1E2486A17900A27979 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				008968892486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				00896A092486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
+				80A6B47026307A0300F83BFD /* BSG_KSCrashType.h in Headers */,
 				0089683F2486DA6C00DC48C2 /* BugsnagMetadataInternal.h in Headers */,
 				008969732486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C32486DA1900DC48C2 /* BugsnagClientInternal.h in Headers */,
@@ -2007,8 +2007,6 @@
 				008969EE2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
 				00AD1F032486A17900A27979 /* RegisterErrorData.h in Headers */,
 				008968EE2486DAB800DC48C2 /* BugsnagFileStore.h in Headers */,
-				00896A2A2486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */,
-				008969DC2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */,
 				008969702486DAD000DC48C2 /* BSG_KSFileUtils.h in Headers */,
 				008969522486DAD000DC48C2 /* BSGOnErrorSentBlock.h in Headers */,
 				00896A062486DAD100DC48C2 /* BSG_KSCrashSentry_MachException.h in Headers */,
@@ -2051,6 +2049,7 @@
 				0089682A2486DA5600DC48C2 /* BugsnagKeys.h in Headers */,
 				008969BF2486DAD100DC48C2 /* BSG_KSMachHeaders.h in Headers */,
 				008968E02486DAA700DC48C2 /* BugsnagPluginClient.h in Headers */,
+				80A6B47426307A0300F83BFD /* BSG_KSCrash.h in Headers */,
 				008969EC2486DAD100DC48C2 /* BSG_KSCrashReport.h in Headers */,
 				008969F22486DAD100DC48C2 /* BSG_KSCrashReportFields.h in Headers */,
 				00896A312486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
@@ -2069,6 +2068,7 @@
 				00AD1F1F2486A17900A27979 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				0089688A2486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				00896A0A2486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
+				80A6B47126307A0300F83BFD /* BSG_KSCrashType.h in Headers */,
 				008968402486DA6C00DC48C2 /* BugsnagMetadataInternal.h in Headers */,
 				008969742486DAD100DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C42486DA1900DC48C2 /* BugsnagClientInternal.h in Headers */,
@@ -2103,8 +2103,6 @@
 				008969EF2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
 				00AD1F042486A17900A27979 /* RegisterErrorData.h in Headers */,
 				008968EF2486DAB800DC48C2 /* BugsnagFileStore.h in Headers */,
-				00896A2B2486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */,
-				008969DD2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */,
 				008969712486DAD000DC48C2 /* BSG_KSFileUtils.h in Headers */,
 				008969532486DAD000DC48C2 /* BSGOnErrorSentBlock.h in Headers */,
 				00896A072486DAD100DC48C2 /* BSG_KSCrashSentry_MachException.h in Headers */,
@@ -2817,6 +2815,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				80A6B47526307A3900F83BFD /* BSG_KSCrash.h in Sources */,
+				80A6B47626307A3900F83BFD /* BSG_KSCrashType.h in Sources */,
 				E7462909248907E500F92D67 /* BSG_KSMach_x86_32.c in Sources */,
 				E746290A248907E500F92D67 /* BSG_KSDynamicLinker.c in Sources */,
 				E746290B248907E500F92D67 /* BSG_KSMach_Arm.c in Sources */,

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -40,6 +40,8 @@
 #import "BugsnagSession.h"
 #import "BugsnagStackframe.h"
 #import "BugsnagThread.h"
+#import "BSG_KSCrash.h"
+#import "BSG_KSCrashType.h"
 
 @interface Bugsnag : NSObject <BugsnagClassLevelMetadataStore>
 


### PR DESCRIPTION
Fix Objective-C imports to resolve a build error that surfaced starting in Xcode 12.5.  This change does two things:

- Adds the `BSG_KSCrash.h` and `BSG_KSCrashType.h` headers to the `BugsnagStatic` scheme
- Imports the `BSG_KSCrash.h` and `BSG_KSCrashType.h` headers in the `Bugsnag.h` header